### PR TITLE
Improve help and error messages related to blocksize

### DIFF
--- a/src/micbench
+++ b/src/micbench
@@ -461,9 +461,9 @@ class IoCommand < BaseCommand
       @options[:aio_tracefile] = file
     end
     @parser.on('-b', '--blocksize SIZE',
-              "Size of IO block (default: 16k)") do |size|
+              "Size of IO block (default: 16KB)") do |size|
       unless @options[:blocksize] = parse_size(size)
-        parse_error.call("invalid argument for --size: #{size}")
+        parse_error.call("invalid argument for --blocksize: #{size}")
       end
     end
     @parser.on('-s', '--offset-start OFFSET',


### PR DESCRIPTION
- A help message of blocksize describe that default value of block size is `16k`, but in fact it means `16kb`. 
- Argument error message of blocksize mentions that `"invalid argument for --size: #{size}"`, but in fact it means `"invalid argument for --blocksize: #{size}"`

We should fix them.
